### PR TITLE
Added "clear", "undo" and "all" options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ git config --global core.editor "emacs"
 # Usage
 
 ```
-$ note [bpieftac] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
+$ note [bpieftacu] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
 ```
 
 The execution command for the note taker can be specified by user choice during installation or manually.
@@ -47,7 +47,7 @@ $ note "<A_NEAT_SUBJECT_GOES_HERE>" "This one line of a Note" "and another line 
 - Usage with options for management
 
 ```
-$ note [-bpeftac] [NS]
+$ note [-bpeftacu] [NS]
 ```
 
 **\-b** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
@@ -75,6 +75,12 @@ grep --ignore-case --before-context=3 --after-context=3 --color --extended-regex
 
 **\-c** &nbsp;&nbsp;&nbsp;
 `clear` clears all notes in the notes file
+
+**\-u** &nbsp;&nbsp;&nbsp;
+`undo` deletes the most recent note in the notes file. Specifically, it deletes the next-to-last
+line and continues deleting lines upwards until it enounters another blank line. This works well
+with notes made using the program prompt but may produce unexpected results if the notes file has
+been interactively edited and no longer follows the default formatting.
 
 # license
 

--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ git config --global core.editor "emacs"
 # Usage
 
 ```
-$ note [bpiefta] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
+$ note [bpieftac] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
 ```
 
 The execution command for the note taker can be specified by user choice during installation or manually.
@@ -47,7 +47,7 @@ $ note "<A_NEAT_SUBJECT_GOES_HERE>" "This one line of a Note" "and another line 
 - Usage with options for management
 
 ```
-$ note [-bpefta] [NS]
+$ note [-bpeftac] [NS]
 ```
 
 **\-b** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
@@ -72,6 +72,9 @@ grep --ignore-case --before-context=3 --after-context=3 --color --extended-regex
 
 **\-a** &nbsp;&nbsp;&nbsp;
 `all` pipes the entire notes file through less for quick analysis
+
+**\-c** &nbsp;&nbsp;&nbsp;
+`clear` clears all notes in the notes file
 
 # license
 

--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ git config --global core.editor "emacs"
 # Usage
 
 ```
-$ note [pieft] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
+$ note [bpiefta] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
 ```
 
 The execution command for the note taker can be specified by user choice during installation or manually.
@@ -47,7 +47,7 @@ $ note "<A_NEAT_SUBJECT_GOES_HERE>" "This one line of a Note" "and another line 
 - Usage with options for management
 
 ```
-$ note [-bpeft] [NS]
+$ note [-bpefta] [NS]
 ```
 
 **\-b** &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
@@ -69,6 +69,9 @@ grep --ignore-case --before-context=3 --after-context=3 --color --extended-regex
 `tail` output last **N** lines of notes (N is optional, defaults to 10)
 
 **NOTE:** see the install instructions to set your editor of choice for `-e` and `-i` options
+
+**\-a** &nbsp;&nbsp;&nbsp;
+`all` pipes the entire notes file through less for quick analysis
 
 # license
 

--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ git config --global core.editor "emacs"
 # Usage
 
 ```
-$ note [bpieftacu] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
+$ note [bpeftacu] [NS] [<SUBJECT>] [<MESSAGE_LINE_1>] [<MESSAGE_LINE_2>] ...
 ```
 
 The execution command for the note taker can be specified by user choice during installation or manually.

--- a/note_taker.bash
+++ b/note_taker.bash
@@ -61,6 +61,22 @@ handle_options () {
 	    # -a for all: pipes the whole notes file through less for quick, easy viewing
 	    cat "$NOTE_PAD_PATH" | less
 	    ;;
+	"-c")
+	    # -c for 'clear notes'
+	    # confirm user intention
+	    read -p "Clear all notes [y/n]? " -n 1 -r CLEAR_REPLY
+	    echo ""
+            # exit if not confirmed
+	    if [[ ! "$CLEAR_REPLY" =~ ^[Yy]$ ]]; then
+	    	echo "Cancelled."
+	    else 
+            	# clear notes file by overwriting it with blankness:
+		> "$NOTE_PAD_PATH"
+		# report success
+		echo "Cleared."
+	    fi
+            echo ""
+	    ;;
         *)
             echo "$1 looks like an argument, please use a valid argument"
             echo "$USAGE_STRING"

--- a/note_taker.bash
+++ b/note_taker.bash
@@ -57,6 +57,10 @@ handle_options () {
             fi
             echo ""
             ;;
+	"-a")
+	    # -a for all: pipes the whole notes file through less for quick, easy viewing
+	    cat "$NOTE_PAD_PATH" | less
+	    ;;
         *)
             echo "$1 looks like an argument, please use a valid argument"
             echo "$USAGE_STRING"

--- a/note_taker.bash
+++ b/note_taker.bash
@@ -77,7 +77,45 @@ handle_options () {
 	    fi
             echo ""
 	    ;;
-        *)
+	"-u")
+	    # -u for 'undo': deletes the most recent note. Specifically, it deletes lines starting
+            # with the next-to-last line and moving upwards through the file, until the next blank
+            # line it encounters.
+	    # confirm user intention
+	    read -p "Clear most recent note [y/n]? " -n 1 -r CLEAR_REPLY
+	    echo ""
+            # exit if not confirmed
+	    if [[ ! "$CLEAR_REPLY" =~ ^[Yy]$ ]]; then
+	    	echo "Cancelled."
+	    else 
+        	# get the total number of lines in the notes file
+		LINES=`cat "$NOTE_PAD_PATH" | wc -l`
+		# get the penultimate line, as the last line is always blank
+		((LINES--))
+		# get the text of the penultimate line and assign it to LINE_TEXT
+		LINE_NUMBER=$LINES
+		# get the text of the penultimate line and assign it to LINE_TEXT
+		LINE_TEXT=`tail -n +"$LINE_NUMBER" "$NOTE_PAD_PATH" | head -n 1`
+		# as long as LINE_TEXT is not empty and LINE_NUMBER is not 0
+		until [ -z "$LINE_TEXT" ] || [ "$LINE_NUMBER" -eq 0 ]; do
+			# delete the last line of the notes file by copying a shortened version
+			# to a temp file and then overwriting the original with the temp
+			head -n -1 "$NOTE_PAD_PATH" > temp.txt
+			mv temp.txt "$NOTE_PAD_PATH"
+			# decrement the current variable for the current line number
+			((LINE_NUMBER--))
+			# get the text of the new last line
+			LINE_TEXT=`tail -n +"$LINE_NUMBER" "$NOTE_PAD_PATH" | head -n 1`
+		done
+		# outside of the loop we need to delete one more line to complete the clear process
+		head -n -1 "$NOTE_PAD_PATH" > temp.txt
+		mv temp.txt "$NOTE_PAD_PATH"
+		# report success
+		echo "Cleared."
+	    fi
+ 	    echo ""
+	    ;;
+	*)
             echo "$1 looks like an argument, please use a valid argument"
             echo "$USAGE_STRING"
             ;;


### PR DESCRIPTION
Hi John! I've been playing with the note-taker app and added a few commands I thought I would like:
- "-c" clears all notes in the notes file
- "-a" pipes the notes file through less (a bit quicker for just checking than the -i/-e option)
-"-u" for undo, deletes the most recent note (deletes from the next-to-last line upwards till it reaches another empty line)
I also edited the README to include the added options, and I thought you might be interested in checking them out and maybe pulling them. Thank you! 